### PR TITLE
Encrypted by default

### DIFF
--- a/getIP
+++ b/getIP
@@ -2,7 +2,7 @@
 #gets public IP address and displays in Terminal
 IPurl="http://ipecho.net/plain"
 
-if curl --max-time 5 $IPurl; then 
+if curl -s -m 5 $IPurl; then
 # print a newline after result
 echo
 else

--- a/getIP
+++ b/getIP
@@ -1,13 +1,20 @@
-
 #!/bin/bash
 # gets public IP address and displays in Terminal
 # Michael Hirsch
 # https://scivision.co
+#
+# Note: if you get error message curl: (77) error setting certificate verify locations:
+# curl can't find your certificates. Fix this by:
+#
+# sudo mkdir -p /etc/pki/tls/certs
+# sudo ln /etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt
+#
+# Ref: http://stackoverflow.com/questions/3160909/how-do-i-deal-with-certificates-using-curl-while-trying-to-access-an-https-url
+#
 
-url=('v4.ident.me' 'ipecho.net/plain' 'wtfismyip.com/text')
+url=('https://api.ipify.org' 'http://v4.ident.me' 'http://ipecho.net/plain' 'http://wtfismyip.com/text')
 
 for u in ${url[@]}; do
- if curl -m 4 $u; then 
-    echo; break
+ if curl -m 4 $u; then echo; break
  fi
 done

--- a/getIP
+++ b/getIP
@@ -1,10 +1,13 @@
-#!/bin/bash
-#gets public IP address and displays in Terminal
-IPurl="http://ipecho.net/plain"
 
-if curl --max-time 5 $IPurl; then 
-# print a newline after result
-echo
-else
-    echo Could not connect to $IPurl, sorry
-fi
+#!/bin/bash
+# gets public IP address and displays in Terminal
+# Michael Hirsch
+# https://scivision.co
+
+url=('v4.ident.me' 'ipecho.net/plain' 'wtfismyip.com/text')
+
+for u in ${url[@]}; do
+ if curl -m 4 $u; then 
+    echo; break
+ fi
+done


### PR DESCRIPTION
This method now can try several sites if the first site is down. The first site uses an encrypted HTTPS connection.
